### PR TITLE
Remove the throwing of an error in the `setImage` method

### DIFF
--- a/Examples/iOSGreedyKit/iOSGreedyKit/Controllers/ImageViewController.swift
+++ b/Examples/iOSGreedyKit/iOSGreedyKit/Controllers/ImageViewController.swift
@@ -73,7 +73,7 @@ final class ImageViewController: UIViewController {
     }
 
     private func addImage() {
-        try? imageView.setImage(localImage)
+        imageView.setImage(localImage)
     }
 }
 

--- a/Sources/GreedyKit/UIKit/GreedyImageView.swift
+++ b/Sources/GreedyKit/UIKit/GreedyImageView.swift
@@ -39,21 +39,21 @@ public final class GreedyImageView: GreedyMediaView {
 }
 
 extension GreedyImageView {
-    public func setImage(_ cgImage: CGImage) throws {
+    public func setImage(_ cgImage: CGImage) {
         guard let buffer = cgImage.sampleBuffer else {
             return
         }
         renderView.enqueueBuffer(buffer)
     }
     
-    public func setImage(_ uiImage: UIImage) throws {
+    public func setImage(_ uiImage: UIImage) {
         guard let cgImage = uiImage.cgImage else {
             return
         }
         try setImage(cgImage)
     }
     
-    public func setImage(_ ciImage: CIImage) throws {
+    public func setImage(_ ciImage: CIImage) {
         guard let cgImage = context?.createCGImage(ciImage, from: ciImage.extent) else {
             return
         }


### PR DESCRIPTION
I decided to remove the throw out error entirely, because the responsibility for the inability to retrieve data from an image should lie with the image or its sender, not with the tool that uses it.

Closes #5